### PR TITLE
Better Error Handling

### DIFF
--- a/SRanipalExtTrackingModule/SRanipalTrackingInterface.cs
+++ b/SRanipalExtTrackingModule/SRanipalTrackingInterface.cs
@@ -29,9 +29,6 @@ namespace SRanipalExtTrackingInterface
         internal static IntPtr _processHandle;
         internal static IntPtr _offset;
         
-        LipData_v2 lipData;
-        EyeData_v2 eyeData;
-        
         private static byte[] eyeImageCache, lipImageCache;
         
         // Kernel32 SetDllDirectory
@@ -169,6 +166,7 @@ namespace SRanipalExtTrackingInterface
                 lipData.image = Marshal.AllocCoTaskMem(UnifiedTracking.LipImageData.ImageSize.x *
                                                        UnifiedTracking.LipImageData.ImageSize.x);
 
+                UnifiedTracking.LipImageData.ImageData = new byte[SRanipal_Lip_v2.ImageWidth * SRanipal_Lip_v2.ImageHeight * 4];
                 lipImageCache = new byte[SRanipal_Lip_v2.ImageWidth * SRanipal_Lip_v2.ImageHeight];
             }
 

--- a/SRanipalExtTrackingModule/SRanipal_API.cs
+++ b/SRanipalExtTrackingModule/SRanipal_API.cs
@@ -6,34 +6,33 @@ namespace ViveSR
 {
     namespace anipal
     {
-        public class SRanipal_API
+        public static class SRanipal_API
         {
-            /// <summary>
-            /// Invokes an anipal module.
-            /// </summary>
-            /// <param name="anipalType">The index of an anipal module.</param>
-            /// <param name="config">Indicates the resulting ViveSR.Error status of this method.</returns>
-            /// <returns>Indicates the resulting ViveSR.Error status of this method.</returns>
-            [DllImport("SRanipal")]
-            public static extern Error Initial(int anipalType, IntPtr config);
+            [DllImport("kernel32.dll", SetLastError = true)]
+            private static extern IntPtr LoadLibrary(string dllToLoad);
 
-            /// <summary>
-            /// Terminates an anipal module.
-            /// </summary>
-            /// <param name="anipalType">The index of an anipal module.</param>
-            /// <returns>Indicates the resulting ViveSR.Error status of this method.</returns>
-            [DllImport("SRanipal")]
-            public static extern Error Release(int anipalType);
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool FreeLibrary(IntPtr hModule);
 
-            /// <summary>
-            /// Gets the status of an anipal module.
-            /// </summary>
-            /// <param name="anipalType">The index of an anipal module.</param>
-            /// <param name="status">The status of an anipal module.</param>
-            /// <returns>Indicates the resulting ViveSR.Error status of this method.</returns>
-            [DllImport("SRanipal")]
-            public static extern Error GetStatus(int anipalType, out AnipalStatus status);
+            private static IntPtr module = IntPtr.Zero;
 
+            public static void InitialRuntime()
+            {
+                if (module != IntPtr.Zero) 
+                    ReleaseRuntime();
+                module = LoadLibrary("SRanipal.dll");
+            }
+
+            public static void ReleaseRuntime()
+            {
+                if (!FreeLibrary(module)) // ideally should never happen.
+                    throw new Exception($"Failed to release Lip module DLL.");
+                module = IntPtr.Zero;
+            }
+
+            [DllImport("SRanipal.dll", CallingConvention = CallingConvention.Cdecl)]
+            internal static extern Error Initial(int anipalType, IntPtr config);
         }
     }
 }


### PR DESCRIPTION
This PR draft includes several changes to the module, including better error handling, covering edge cases such as the notorious USB issue and wireless reinitialization. This also implements an unloader for the SRanipal API to circumvent locking behaviors within the library itself.

Important notes:
* The SRanipal API does not initialize well with separate threads. I tried implementing a secondary feature in which data updates would be unimpeded while the errored runtimes were reinitialized, but this locked up the launched thread (likely due to deadlocking behavior). Currently have it so that it is all done sequentially as before, but maybe we could look into locking certain sequences or reworking the API in order to avoid these deadlocking scenarios.
* The SRanipal runtime itself handles the changes fairly well.
* This doesn't entirely fix the USB issue but can be useful in unblocking the init.
* I have not tested with Vive wireless, but this should completely automate any weird errors if it doesn't work the first time (no need to restart VRCFT or reinitialize the module).